### PR TITLE
Xiaomi/lavender: add built-in earpiece and microphone

### DIFF
--- a/ucm2/Xiaomi/lavender/HiFi.conf
+++ b/ucm2/Xiaomi/lavender/HiFi.conf
@@ -14,6 +14,52 @@ SectionVerb {
 	}
 }
 
+SectionDevice."Earpiece" {
+	Comment "Built-in Earpiece"
+
+	EnableSequence [
+		cset "name='Digital RX1 MIX1 INP1' RX1"
+		cset "name='Analog EAR_S' Switch"
+	]
+
+	DisableSequence [
+		cset "name='Digital RX1 MIX1 INP1' ZERO"
+		cset "name='Analog EAR_S' ZERO"
+	]
+
+	ConflictingDevices [
+		"Headphones"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Microphone" {
+	Comment "Built-in Microphone"
+
+	EnableSequence [
+		cset "name='Digital CIC1 MUX' AMIC"
+		cset "name='Digital DEC1 MUX' ADC1"
+	]
+
+	DisableSequence [
+		cset "name='Digital DEC1 MUX' ZERO"
+	]
+
+	ConflictingDevices [
+		"Headset Mic"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CapturePriority 100
+		CaptureChannels 1
+	}
+}
+
 SectionDevice."Headphones" {
 	Comment "Headphones (3.5 mm jack)"
 
@@ -29,6 +75,10 @@ SectionDevice."Headphones" {
 		cset "name='Digital RX2 MIX1 INP1' ZERO"
 		cset "name='Analog HPHL' ZERO"
 		cset "name='Analog HPHR' ZERO"
+	]
+
+	ConflictingDevices [
+		"Earpiece"
 	]
 
 	Value {
@@ -51,6 +101,11 @@ SectionDevice."Headset Mic" {
 		cset "name='Digital DEC1 MUX' ZERO"
 		cset "name='Analog ADC2 MUX' ZERO"
 	]
+
+	ConflictingDevices [
+		"Microphone"
+	]
+
 	Value {
 		CapturePCM "hw:${CardId},1"
 		CapturePriority 200


### PR DESCRIPTION
The earpiece and microphone are both on the WCD codec, like the headphone jack. Add the built-in earpiece and microphone.