### PR TITLE
ucm2: sdm660-internal: drop "Analog" prefix

### DIFF
--- a/ucm2/Asus/x00td/HiFi.conf
+++ b/ucm2/Asus/x00td/HiFi.conf
@@ -20,15 +20,15 @@ SectionDevice."Headphones" {
 	EnableSequence [
 		cset "name='Digital RX1 MIX1 INP1' RX1"
 		cset "name='Digital RX2 MIX1 INP1' RX2"
-		cset "name='Analog HPHL' Switch"
-		cset "name='Analog HPHR' Switch"
+		cset "name='HPHL' Switch"
+		cset "name='HPHR' Switch"
 	]
 
 	DisableSequence [
 		cset "name='Digital RX1 MIX1 INP1' ZERO"
 		cset "name='Digital RX2 MIX1 INP1' ZERO"
-		cset "name='Analog HPHL' ZERO"
-		cset "name='Analog HPHR' ZERO"
+		cset "name='HPHL' ZERO"
+		cset "name='HPHR' ZERO"
 	]
 
 	Value {
@@ -44,12 +44,12 @@ SectionDevice."Headset Mic" {
 	EnableSequence [
 		cset "name='Digital CIC1 MUX' AMIC"
 		cset "name='Digital DEC1 MUX' ADC2"
-		cset "name='Analog ADC2 MUX' INP2"
+		cset "name='ADC2 MUX' INP2"
 	]
 
 	DisableSequence [
 		cset "name='Digital DEC1 MUX' ZERO"
-		cset "name='Analog ADC2 MUX' ZERO"
+		cset "name='ADC2 MUX' ZERO"
 	]
 	Value {
 		CapturePCM "hw:${CardId},1"

--- a/ucm2/Asus/x00td/x00td.conf
+++ b/ucm2/Asus/x00td/x00td.conf
@@ -13,9 +13,9 @@ BootSequence [
 	cset "name='Digital RX2 Digital Volume' 84"
 
 	# Headset Microphone
-	cset "name='Analog ADC2 Volume' 8"
+	cset "name='ADC2 Volume' 8"
 ]
 
 FixedBootSequence [
-	cset "name='Analog RDAC2 MUX' RX2"
+	cset "name='RDAC2 MUX' RX2"
 ]

--- a/ucm2/Xiaomi/clover/HiFi.conf
+++ b/ucm2/Xiaomi/clover/HiFi.conf
@@ -20,15 +20,15 @@ SectionDevice."Headphones" {
 	EnableSequence [
 		cset "name='Digital RX1 MIX1 INP1' RX1"
 		cset "name='Digital RX2 MIX1 INP1' RX2"
-		cset "name='Analog HPHL' Switch"
-		cset "name='Analog HPHR' Switch"
+		cset "name='HPHL' Switch"
+		cset "name='HPHR' Switch"
 	]
 
 	DisableSequence [
 		cset "name='Digital RX1 MIX1 INP1' ZERO"
 		cset "name='Digital RX2 MIX1 INP1' ZERO"
-		cset "name='Analog HPHL' ZERO"
-		cset "name='Analog HPHR' ZERO"
+		cset "name='HPHL' ZERO"
+		cset "name='HPHR' ZERO"
 	]
 
 	Value {
@@ -44,12 +44,12 @@ SectionDevice."Headset Mic" {
 	EnableSequence [
 		cset "name='Digital CIC1 MUX' AMIC"
 		cset "name='Digital DEC1 MUX' ADC2"
-		cset "name='Analog ADC2 MUX' INP2"
+		cset "name='ADC2 MUX' INP2"
 	]
 
 	DisableSequence [
 		cset "name='Digital DEC1 MUX' ZERO"
-		cset "name='Analog ADC2 MUX' ZERO"
+		cset "name='ADC2 MUX' ZERO"
 	]
 	Value {
 		CapturePCM "hw:${CardId},1"

--- a/ucm2/Xiaomi/clover/clover.conf
+++ b/ucm2/Xiaomi/clover/clover.conf
@@ -13,9 +13,9 @@ BootSequence [
 	cset "name='Digital RX2 Digital Volume' 84"
 
 	# Headset Microphone
-	cset "name='Analog ADC2 Volume' 8"
+	cset "name='ADC2 Volume' 8"
 ]
 
 FixedBootSequence [
-	cset "name='Analog RDAC2 MUX' RX2"
+	cset "name='RDAC2 MUX' RX2"
 ]

--- a/ucm2/Xiaomi/lavender/HiFi.conf
+++ b/ucm2/Xiaomi/lavender/HiFi.conf
@@ -19,12 +19,12 @@ SectionDevice."Earpiece" {
 
 	EnableSequence [
 		cset "name='Digital RX1 MIX1 INP1' RX1"
-		cset "name='Analog EAR_S' Switch"
+		cset "name='EAR_S' Switch"
 	]
 
 	DisableSequence [
 		cset "name='Digital RX1 MIX1 INP1' ZERO"
-		cset "name='Analog EAR_S' ZERO"
+		cset "name='EAR_S' ZERO"
 	]
 
 	ConflictingDevices [
@@ -66,15 +66,15 @@ SectionDevice."Headphones" {
 	EnableSequence [
 		cset "name='Digital RX1 MIX1 INP1' RX1"
 		cset "name='Digital RX2 MIX1 INP1' RX2"
-		cset "name='Analog HPHL' Switch"
-		cset "name='Analog HPHR' Switch"
+		cset "name='HPHL' Switch"
+		cset "name='HPHR' Switch"
 	]
 
 	DisableSequence [
 		cset "name='Digital RX1 MIX1 INP1' ZERO"
 		cset "name='Digital RX2 MIX1 INP1' ZERO"
-		cset "name='Analog HPHL' ZERO"
-		cset "name='Analog HPHR' ZERO"
+		cset "name='HPHL' ZERO"
+		cset "name='HPHR' ZERO"
 	]
 
 	ConflictingDevices [
@@ -94,12 +94,12 @@ SectionDevice."Headset Mic" {
 	EnableSequence [
 		cset "name='Digital CIC1 MUX' AMIC"
 		cset "name='Digital DEC1 MUX' ADC2"
-		cset "name='Analog ADC2 MUX' INP2"
+		cset "name='ADC2 MUX' INP2"
 	]
 
 	DisableSequence [
 		cset "name='Digital DEC1 MUX' ZERO"
-		cset "name='Analog ADC2 MUX' ZERO"
+		cset "name='ADC2 MUX' ZERO"
 	]
 
 	ConflictingDevices [

--- a/ucm2/Xiaomi/lavender/lavender.conf
+++ b/ucm2/Xiaomi/lavender/lavender.conf
@@ -13,9 +13,9 @@ BootSequence [
 	cset "name='Digital RX2 Digital Volume' 84"
 
 	# Headset Microphone
-	cset "name='Analog ADC2 Volume' 8"
+	cset "name='ADC2 Volume' 8"
 ]
 
 FixedBootSequence [
-	cset "name='Analog RDAC2 MUX' RX2"
+	cset "name='RDAC2 MUX' RX2"
 ]


### PR DESCRIPTION
This is a follow up of these changes https://github.com/sdm660-mainline/linux/compare/d0d34727834e9029d3caf859ca59b868c18cf6d7..8563ba07900489faf5410f61c02f3ce158ec9461