### PR TITLE
BlackBerry/luna: Add ucm2 config for Headphones/Earpiece

### DIFF
--- a/ucm2/BlackBerry/luna/HiFi.conf
+++ b/ucm2/BlackBerry/luna/HiFi.conf
@@ -1,0 +1,68 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='LPI_MI2S_RX_0 Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer LPI_MI2S_TX_3' 1"
+	]
+
+	DisableSequence [
+		cset "name='LPI_MI2S_RX_0 Audio Mixer MultiMedia1' 0"
+		cset "name='MultiMedia2 Mixer LPI_MI2S_TX_3' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+
+SectionDevice."Earpiece" {
+	Comment "Built-in Earpiece"
+
+	EnableSequence [
+		cset "name='Digital RX1 MIX1 INP1' RX1"
+		cset "name='EAR_S' Switch"
+	]
+
+	DisableSequence [
+		cset "name='Digital RX1 MIX1 INP1' ZERO"
+		cset "name='EAR_S' ZERO"
+	]
+
+	ConflictingDevices [
+		"Headphones"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Headphones" {
+	Comment "Headphones (3.5 mm jack)"
+
+	EnableSequence [
+		cset "name='Digital RX1 MIX1 INP1' RX1"
+		cset "name='Digital RX2 MIX1 INP1' RX2"
+		cset "name='HPHL' Switch"
+		cset "name='HPHR' Switch"
+	]
+
+	DisableSequence [
+		cset "name='Digital RX1 MIX1 INP1' ZERO"
+		cset "name='Digital RX2 MIX1 INP1' ZERO"
+		cset "name='HPHL' ZERO"
+		cset "name='HPHR' ZERO"
+	]
+
+	ConflictingDevices [
+		"Earpiece"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 200
+		JackControl "Headphone Jack"
+		PlaybackChannels 2
+	}
+}

--- a/ucm2/BlackBerry/luna/luna.conf
+++ b/ucm2/BlackBerry/luna/luna.conf
@@ -1,0 +1,21 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/BlackBerry/luna/HiFi.conf"
+	Comment "HiFi audio"
+}
+
+# Volume defaults should be declared in the boot sequence so they can be
+# overriden by the user.
+BootSequence [
+	# Headphones
+	cset "name='Digital RX1 Digital Volume' 84"
+	cset "name='Digital RX2 Digital Volume' 84"
+
+	# Headset Microphone
+	cset "name='ADC2 Volume' 8"
+]
+
+FixedBootSequence [
+	cset "name='RDAC2 MUX' RX2"
+]

--- a/ucm2/conf.d/sdm660/BlackBerry KEY2.conf
+++ b/ucm2/conf.d/sdm660/BlackBerry KEY2.conf
@@ -1,0 +1,1 @@
+../../BlackBerry/luna/luna.conf

--- a/ucm2/conf.d/sdm660/bbry-BlackBerryKEY2LE.conf
+++ b/ucm2/conf.d/sdm660/bbry-BlackBerryKEY2LE.conf
@@ -1,0 +1,1 @@
+../../BlackBerry/luna/luna.conf


### PR DESCRIPTION
This device has a speaker amp connected to it's headphone codec lines. So in future, it should be easy to support Speaker too, albeit potentially confusing.

But first I need to create/adapt Awinic kernel drivers for the AW87319 amplifier

Already tested speaker amplifier via manual i2cset commands

Microphones might be easily added, similar to other SDM660 devices, but I don't have time to test them right now, so leaving them out.