### PR TITLE
Xiaomi/jasmine: add UCM config for the Xiaomi Mi A2

### DIFF
--- a/ucm2/Xiaomi/jasmine/HiFi.conf
+++ b/ucm2/Xiaomi/jasmine/HiFi.conf
@@ -1,0 +1,81 @@
+SectionVerb {
+	EnableSequence [
+		cset "name='INT0_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='MultiMedia2 Mixer INT3_MI2S_TX' 1"
+	]
+
+	DisableSequence [
+		cset "name='INT0_MI2S_RX Audio Mixer MultiMedia1' 0"
+		cset "name='MultiMedia2 Mixer INT3_MI2S_TX' 0"
+	]
+
+	Value {
+		TQ "HiFi"
+	}
+}
+
+SectionDevice."Earpiece" {
+	Comment "Built-in Earpiece"
+
+	EnableSequence [
+		cset "name='Digital RX1 MIX1 INP1' RX1"
+		cset "name='RDAC2 MUX' RX1"
+		cset "name='EAR_S' Switch"
+	]
+
+	DisableSequence [
+		cset "name='Digital RX1 MIX1 INP1' ZERO"
+		cset "name='EAR_S' ZERO"
+	]
+
+	ConflictingDevices [
+		"Speaker"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 100
+	}
+}
+
+SectionDevice."Mic" {
+	Comment "Built-in Microphone"
+
+	EnableSequence [
+		cset "name='Digital CIC1 MUX' AMIC"
+		cset "name='Digital DEC1 MUX' ADC1"
+	]
+
+	DisableSequence [
+		cset "name='Digital DEC1 MUX' ZERO"
+	]
+
+	Value {
+		CapturePCM "hw:${CardId},1"
+		CapturePriority 100
+		CaptureChannels 1
+	}
+}
+
+SectionDevice."Speaker" {
+	Comment "Built-in Speaker (TAS2557 smart amplifier)"
+
+	EnableSequence [
+		cset "name='PRI_MI2S_RX Audio Mixer MultiMedia1' 1"
+		cset "name='Speaker Switch' 1"
+	]
+
+	DisableSequence [
+		cset "name='Speaker Switch' 0"
+		cset "name='PRI_MI2S_RX Audio Mixer MultiMedia1' 0"
+	]
+
+	ConflictingDevices [
+		"Earpiece"
+	]
+
+	Value {
+		PlaybackPCM "hw:${CardId},0"
+		PlaybackPriority 300
+	}
+}

--- a/ucm2/Xiaomi/jasmine/jasmine.conf
+++ b/ucm2/Xiaomi/jasmine/jasmine.conf
@@ -1,0 +1,16 @@
+Syntax 3
+
+SectionUseCase."HiFi" {
+	File "/Xiaomi/jasmine/HiFi.conf"
+	Comment "HiFi audio"
+}
+
+# Volume defaults should be declared in the boot sequence so they can be
+# overriden by the user.
+BootSequence [
+	# Earpiece
+	cset "name='Digital RX1 Digital Volume' 84"
+
+	# Speaker (TAS2557) — 0..15 maps to -28..+2 dB; 14 = 0 dB
+	cset "name='Speaker Volume' 14"
+]

--- a/ucm2/conf.d/sdm660-internal/Xiaomi Mi A2.conf
+++ b/ucm2/conf.d/sdm660-internal/Xiaomi Mi A2.conf
@@ -1,0 +1,1 @@
+../../Xiaomi/jasmine/jasmine.conf


### PR DESCRIPTION
Add a use-case configuration for the Xiaomi Mi A2 (jasmine) sdm660 internal sound card: the built-in Earpiece and Microphone on the PM660L codec, and a Speaker routed through the TAS2557 smart amplifier on Primary MI2S.  The device has no 3.5 mm jack, so no headphone devices are defined.